### PR TITLE
Fix deprecated consts and error linked to async call within thread

### DIFF
--- a/custom_components/gazpar/sensor.py
+++ b/custom_components/gazpar/sensor.py
@@ -15,7 +15,7 @@ from custom_components.gazpar.util import Util
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_USERNAME, CONF_SCAN_INTERVAL, ENERGY_KILO_WATT_HOUR
+from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_USERNAME, CONF_SCAN_INTERVAL, UnitOfEnergy
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval, call_later
@@ -108,7 +108,7 @@ class GazparAccount:
         self._errorMessages = []
 
         self.sensors.append(
-            GazparSensor(name, PropertyName.ENERGY.value, ENERGY_KILO_WATT_HOUR, self))
+            GazparSensor(name, PropertyName.ENERGY.value, UnitOfEnergy.KILO_WATT_HOUR, self))
 
         if hass is not None:
             call_later(hass, 5, self.update_gazpar_data)
@@ -150,7 +150,7 @@ class GazparAccount:
 
         if event_time is not None:
             for sensor in self.sensors:
-                sensor.async_schedule_update_ha_state(True)
+                sensor.schedule_update_ha_state(True)
             _LOGGER.debug("HA notified that new data are available")
 
     # ----------------------------------

--- a/custom_components/gazpar/util.py
+++ b/custom_components/gazpar/util.py
@@ -1,6 +1,6 @@
 from pygazpar.enum import PropertyName, Frequency
-from homeassistant.const import CONF_USERNAME, ATTR_ATTRIBUTION, ATTR_UNIT_OF_MEASUREMENT, ATTR_FRIENDLY_NAME, ATTR_ICON, ATTR_DEVICE_CLASS, ENERGY_KILO_WATT_HOUR, DEVICE_CLASS_ENERGY
-from homeassistant.components.sensor import ATTR_STATE_CLASS, STATE_CLASS_TOTAL_INCREASING
+from homeassistant.const import CONF_USERNAME, ATTR_ATTRIBUTION, ATTR_UNIT_OF_MEASUREMENT, ATTR_FRIENDLY_NAME, ATTR_ICON, ATTR_DEVICE_CLASS, UnitOfEnergy
+from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass, SensorDeviceClass
 from typing import Any, Union
 
 from custom_components.gazpar.manifest import Manifest
@@ -57,11 +57,11 @@ class Util:
             ATTR_VERSION: Manifest.version(),
             CONF_USERNAME: username,
             ATTR_PCE: pceIdentifier,
-            ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
             ATTR_FRIENDLY_NAME: SENSOR_FRIENDLY_NAME,
             ATTR_ICON: ICON_GAS,
-            ATTR_DEVICE_CLASS: DEVICE_CLASS_ENERGY,
-            ATTR_STATE_CLASS: STATE_CLASS_TOTAL_INCREASING,
+            ATTR_DEVICE_CLASS: SensorDeviceClass.ENERGY,
+            ATTR_STATE_CLASS: SensorStateClass.TOTAL_INCREASING,
             ATTR_ERROR_MESSAGES: errorMessages,
             str(Frequency.HOURLY): {},
             str(Frequency.DAILY): {},


### PR DESCRIPTION
Fix warning linked to use of deprecated constants.
Fix the error raised by the call of `sensor.async_schedule_update_ha_state`